### PR TITLE
Make mr_sendemail.py be found by Python  Fixes JoeSchmuck/Multi-Report#9

### DIFF
--- a/multi_report_v3.14_2025_01_28.txt
+++ b/multi_report_v3.14_2025_01_28.txt
@@ -2395,6 +2395,7 @@ else
 	
 # Sendemail Courtesy of @oxyde
 
+cd $SCRIPT_DIR
 python3 mr_sendemail.py \
 	--subject "$subject" \
 	--to_address "$Email" \
@@ -2403,7 +2404,7 @@ python3 mr_sendemail.py \
 
 # Check Exit Code
 	if [[ $? -ne 0 ]]; then
-		echo "Sendemail had a problem.  Check the file log at "$SCRIPTS"/sendmail_log"
+		echo "Sendemail had a problem.  Check the file log at "$SCRIPT_DIR"/sendmail_log"
 		cat /tmp/sendemail_error.txt
 	else
 		echo "Email Sent"


### PR DESCRIPTION
Kept on getting error: "Current user doesn't have permission in the execution folder: /" when trying to run cron job and send email using mr_sendemail.py. Error message that script generated included " python3: can't open file '//mr_sendemail.py': [Errno 2] No such file or directory".

Fixes JoeSchmuck/Multi-Report#9
